### PR TITLE
Add model lookup when building fixtures

### DIFF
--- a/lib/fixture_builder/builder.rb
+++ b/lib/fixture_builder/builder.rb
@@ -96,7 +96,7 @@ module FixtureBuilder
       Date::DATE_FORMATS[:default] = Date::DATE_FORMATS[:db]
       begin
         fixtures = tables.inject([]) do |files, table_name|
-          table_klass = table_name.classify.constantize rescue nil
+          table_klass = @namer.lookup_klass(table_name)
           if table_klass && table_klass < ActiveRecord::Base
             rows = table_klass.unscoped do
               table_klass.order(:id).all.collect do |obj|

--- a/lib/fixture_builder/namer.rb
+++ b/lib/fixture_builder/namer.rb
@@ -7,6 +7,7 @@ module FixtureBuilder
       @custom_names = {}
       @model_name_procs = {}
       @record_names = {}
+      @klass_lookup = {}
     end
 
     def name_model_with(model_class, &block)
@@ -18,9 +19,18 @@ module FixtureBuilder
       model_objects.each do |model_object|
         raise "Cannot name a blank object" unless model_object.present?
         key = [model_object.class.table_name, model_object.id]
+        @klass_lookup[model_object.class.table_name] = model_object.class
         raise "Cannot set name for #{key.inspect} object twice" if @custom_names[key]
         @custom_names[key] = custom_name
         model_object
+      end
+    end
+
+    def lookup_klass(table_name)
+      if @klass_lookup[table_name]
+        @klass_lookup[table_name]
+      else
+        table_name.classify.constantize rescue nil
       end
     end
 


### PR DESCRIPTION
## Problem

Fixture builder naively tries to figure out what model to base it's fixture files on by looking at the list of tables we have declared in the db, and just constant-izing them. So if we have a table called `jobs`, it will

This definitely doesn't work with engines (where models are named-spaced like `TaskRabbit::User`). So when it does this, it actually raises an error - but `fixture_builder` then rescues all errors to return `nil` and falls back to backup case that uses raw SQL to try and figure out what columns are on a given table and go from there.

For most db types, this generally works - however when using a JSON type, the fallback raw AR query won't return back proper casted objects (it just returns strings instead). And when we `to_yaml` the results to build the fixture files, we get strings in our fixtures instead of proper arrays / objects, and things break.

## Solution

When iterating through models before building them, create a lookup hash that can match table names to an actual class in the system that uses that table. That way, we can properly match up tables to classes, and build objects using mode class attributes, which will support the proper casting for complex values.